### PR TITLE
Fix firebase deployment

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -119,7 +119,10 @@ steps:
     - name: static_page
       path: /etc/static_page
   commands:
+    - rm -rf /etc/static_page/*
     - cp -R /usr/share/nginx/html/* /etc/static_page
+  depends_on:
+    - build
 
 - name: publish-firebase
   image: devillex/docker-firebase


### PR DESCRIPTION
This fixes the copying of the static files before deploying to firebase. The files were copied before the new container was built.